### PR TITLE
Fix fetch timeout prettier formatting

### DIFF
--- a/src/lib/fetchConfig.ts
+++ b/src/lib/fetchConfig.ts
@@ -135,10 +135,9 @@ async function fetchWithTimeout<T>(url: string, timeoutMs = 10000): Promise<T> {
     return (await response.json()) as T;
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      throw Object.assign(
-        new Error(`Request timeout for ${url} after ${timeoutMs}ms`),
-        { cause: error }
-      );
+      throw Object.assign(new Error(`Request timeout for ${url} after ${timeoutMs}ms`), {
+        cause: error,
+      });
     }
 
     throw error;


### PR DESCRIPTION
This change removes the remaining Prettier-driven ESLint warnings in `fetchConfig.ts` so the repo lint run stays clean.

It reformats the timeout error construction in `fetchWithTimeout` to match the project's Prettier output without changing behavior.